### PR TITLE
Node 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
   libsecret-1-dev \
   # libc6-dev-i386 needed to build for 32-bit (keytar native)
   libc6-dev-i386
-RUN apt-get install -y --install-recommends winehq-stable
+RUN apt-get install -y --allow-unauthenticated --install-recommends winehq-stable
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # build stubbed signtool.exe which can run under wine and call osslsigntool

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/node:8-stretch-browsers
+FROM circleci/node:10-stretch-browsers
 
 ENV MONO_VERSION 4.8.0.495
 


### PR DESCRIPTION
Update our Docker image to node 10 (which is the same version that Electron 4 runs on -- it's not necessary for the version to match, but it's nice to run our node/electron tests on the same version that the application runs on).

A side-effect of this is that once we merge to master and it rebuilds the latest tag, that build will pull in the latest everything (yarn, Chrome, etc.)